### PR TITLE
Paragraph margin change had unintended effects on the directory preference panel, added CSS to ensure spacing is correct there. 

### DIFF
--- a/pdp/mock.py
+++ b/pdp/mock.py
@@ -63,7 +63,7 @@ def mock_irws_person(netid, irws_root='/registry-dev/v2',
                      employee_emails=('jane@example.edu',
                                       'jane-test@example.com'),
                      employee_publish='Y',  # 'Y', 'N', or 'E' (default 'Y')
-                     student_publish='N',  # 'Y' or 'N', default 'Y
+                     student_publish='Y',  # 'Y' or 'N', default 'Y
                      mailstop='359540',
                      **kwargs):
 

--- a/pdp/mock.py
+++ b/pdp/mock.py
@@ -63,7 +63,7 @@ def mock_irws_person(netid, irws_root='/registry-dev/v2',
                      employee_emails=('jane@example.edu',
                                       'jane-test@example.com'),
                      employee_publish='Y',  # 'Y', 'N', or 'E' (default 'Y')
-                     student_publish='Y',  # 'Y' or 'N', default 'Y
+                     student_publish='N',  # 'Y' or 'N', default 'Y
                      mailstop='359540',
                      **kwargs):
 

--- a/pdp/static/css/cascade.css
+++ b/pdp/static/css/cascade.css
@@ -4,7 +4,11 @@
 }
 
 /* reducing whitespace under directory information */
-#profile-content p {
+.directory-panel p{
+	margin: 0 0 10px !important;
+}
+
+#profile-content p{
 	margin-bottom: 1px;
 }
 /* spacing between message and button */

--- a/pdp/templates/release-settings.html
+++ b/pdp/templates/release-settings.html
@@ -10,7 +10,7 @@
        <ul class="list-group">
            <li ng-show="profile.data.employee" class="list-group-item">
                <!-- Employee publishing info -->
-               <div uib-collapse="profile.isSettingPublish && profile.data.employee" class="directory-panel">
+               <div uib-collapse="profile.isSettingPublish && profile.data.employee">
                    <div ng-show="profile.publishChangeSuccess" class="alert alert-success pn-set-msg"
                         id="publish-change-success"
                         role="alert">

--- a/pdp/templates/release-settings.html
+++ b/pdp/templates/release-settings.html
@@ -2,7 +2,7 @@
 <div class="profile-directory-section" ng-show="profile.data.employee || profile.data.student" >
    <h2>Information Sharing Settings</h2>
 
-   <div class="panel panel-default">
+   <div class="panel panel-default directory-panel">
        <div class="panel-heading">
            <h3 class="panel-title profile-h3">UW Directory</h3>
            <p>The <a href="https://www.washington.edu/home/peopledir/" target="_blank" title="Go to the UW Directory">UW Directory</a> will display the following:</p>
@@ -10,16 +10,16 @@
        <ul class="list-group">
            <li ng-show="profile.data.employee" class="list-group-item">
                <!-- Employee publishing info -->
-               <div uib-collapse="profile.isSettingPublish && profile.data.employee">
+               <div uib-collapse="profile.isSettingPublish && profile.data.employee" class="directory-panel">
                    <div ng-show="profile.publishChangeSuccess" class="alert alert-success pn-set-msg"
                         id="publish-change-success"
                         role="alert">
                         <a href="" class="close" ng-click="profile.publishChangeSuccess = false" aria-label="close">&times;</a>
                             Your UW Directory listing preference has been changed and will be reflected in the <a href="https://www.washington.edu/home/peopledir/" target="_blank" title="Go to the UW Directory">UW Directory</a> immediately.
                     </div>
+                    <h4>The following employee information will be viewable by anyone:</h4>
                     <p ng-show="profile.data.employee.publish == 'N'">You are not included in the UW Directory.</p>
                     <div ng-show="profile.data.employee.publish != 'N'">
-                        <h4>The following employee information will be viewable by anyone:</h4>
                         <ul class="data-list">
                             <li>{{ profile.data.rollup_name }}</li>
                             <li>UW NetID: {{ profile.data.netid }}</li>


### PR DESCRIPTION
I also changed where the heading "The following employee information will be viewable by anyone:" was located to keep it consistent with the student settings below it. On the student settings the heading is always displayed, no matter your wp_publish flag. On the employee, it was hidden for N and showing for Y but now it behaves like the student settings.